### PR TITLE
[xc-vusb] Fix logging in Windows front end.

### DIFF
--- a/Drivers/xenvusb/Device.cpp
+++ b/Drivers/xenvusb/Device.cpp
@@ -747,7 +747,7 @@ FdoUnplugDevice(
 {
     if (!fdoContext->DeviceUnplugged)
     {
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
             __FUNCTION__": %s\n",
             fdoContext->FrontEndPath);
         fdoContext->DeviceUnplugged = TRUE;        
@@ -827,14 +827,17 @@ CleanupDisconnectedDevice(
                         fdoContext->IdleRequest);
                     completeRequest = FALSE;
                 }
-                //
-                // note but ignore. 
-                //
-                TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
-                    __FUNCTION__": Device %p Request %p WdfRequestUnmarkCancelable error %x\n",
-                    fdoContext->WdfDevice,
-                    fdoContext->IdleRequest,
-                    Status);
+                else
+                {
+                    //
+                    // note but ignore. 
+                    //
+                    TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
+                        __FUNCTION__": Device %p Request %p WdfRequestUnmarkCancelable error %x\n",
+                        fdoContext->WdfDevice,
+                        fdoContext->IdleRequest,
+                        Status);
+                }
             }
         }
         WDFREQUEST idleRequest = fdoContext->IdleRequest;
@@ -871,7 +874,7 @@ FdoEvtDeviceD0Exit(
     IN  WDF_POWER_DEVICE_STATE)
 {  
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(device);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s Device %p\n",
         fdoContext->FrontEndPath, 
         fdoContext->WdfDevice);
@@ -879,7 +882,7 @@ FdoEvtDeviceD0Exit(
     WdfTimerStop(fdoContext->WatchdogTimer, TRUE);
     XenDeconfigure(fdoContext);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n"
         "    Direct Transfers: %I64d errors: %I64d largest: %d\n"
         "    Indirect Transfers: %I64d errors: %I64d largest: %d\n",
@@ -895,7 +898,7 @@ FdoEvtDeviceD0Exit(
     //
     // --XT-- Removed tracing of 2 interrupt related values.
     //
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n"
         "    DPC overlap %I64d DPC requeue %I64d\n"
         "    DPC max passes %d DPC max processed %d DPC drain queue requests %d\n",
@@ -922,7 +925,7 @@ VOID FdoEvtDeviceSurpriseRemoval(
 {
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(Device);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s Device %p\n",
         fdoContext->FrontEndPath, 
         fdoContext->WdfDevice);
@@ -941,7 +944,7 @@ NTSTATUS FdoEvtChildListCreateDevice(
     _In_  PWDFDEVICE_INIT ChildInit)
 {
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(WdfChildListGetDevice(ChildList));
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 
@@ -1069,8 +1072,8 @@ FdoEvtDeviceDpcFunc(
 
     ReleaseFdoLock(fdoContext);
 
-    ULONG level = responseCount ? TRACE_LEVEL_INFORMATION : TRACE_LEVEL_VERBOSE;
-    TraceEvents(level, TRACE_DPC,
+    // --XT-- this trace was way too noisy, made it verbose.
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DPC,
         __FUNCTION__": exit responses processed %d passes %d\n",
         responseCount,
         passes);
@@ -1149,7 +1152,7 @@ FdoEvtDeviceFileCreate (
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(Device);
     UNREFERENCED_PARAMETER(FileObject);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s Device %p\n",
         fdoContext->FrontEndPath,
         fdoContext->WdfDevice);
@@ -1265,7 +1268,7 @@ NewWorkItem(
         //
         // ok - allocate a new one.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__": Device %p FreeWorkItems is empty, init count %d\n",
             fdoContext->WdfDevice,
             INIT_WORK_ITEM_COUNT);

--- a/Drivers/xenvusb/Driver.cpp
+++ b/Drivers/xenvusb/Driver.cpp
@@ -124,14 +124,14 @@ DriverEntry(
     CHAR * buildType = "Release";
 #endif
 
-    TraceEvents(TRACE_LEVEL_ERROR, TRACE_DRIVER,
-        "Xenclient Enterprise Virtual USB Controller Version %s.\n",
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER,
+        "OpenXT Virtual USB Controller Version %s.\n",
         VER_PRODUCTVERSION_STR);
-    TraceEvents(TRACE_LEVEL_ERROR, TRACE_DRIVER,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER,
         "%s build created on %s at %s\n",
         buildType,
         __DATE__, __TIME__);
-    TraceEvents(TRACE_LEVEL_ERROR, TRACE_DRIVER,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER,
         "DebugLevel %x DebugFlag %x\n", 
         gDebugLevel, gDebugFlag);
 
@@ -179,7 +179,7 @@ EvtDriverContextCleanup(
 {
     UNREFERENCED_PARAMETER(DriverObject);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DRIVER, __FUNCTION__": Driver unload\n");
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, __FUNCTION__": Driver unload\n");
 }
 
 /*

--- a/Drivers/xenvusb/Queue.cpp
+++ b/Drivers/xenvusb/Queue.cpp
@@ -232,7 +232,7 @@ ProcessRootHubNameRequest(
 
     WdfRequestCompleteWithInformation(Request, Status, Information);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
         __FUNCTION__": request completed with status %x size %d size needed %d output buffer length %d\n",
         Status,
         Information,
@@ -313,7 +313,7 @@ ProcessControllerNameRequest(
         Information = length;
     }
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
         __FUNCTION__": request completed with status %x size %d size needed %d output buffer length %d\n",
         Status,
         Information,
@@ -389,7 +389,7 @@ ProcessDriverKeyNameRequest(
     // C6102 Using lengthNeeded from failed function call at line ... 
     // claims that lengthNeeded is uninitialized. It clearly is initialized.
    #pragma warning(suppress: 6102) 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
         __FUNCTION__": request completed with status %x size %d size needed %d output buffer length %d\n",
         Status,
         Information,
@@ -406,7 +406,7 @@ ProcessCyclePort(
     IN WDFREQUEST Request,
     IN size_t OutputBufferLength)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s for Device %p\n", 
         fdoContext->FrontEndPath,
         fdoContext->WdfDevice);
@@ -660,7 +660,7 @@ ProcessUsbPowerStateMap(
         Information = usbPower->Header.ActualBufferLength;
     }
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
         __FUNCTION__": request completed with status %x size %d\n",
         Status,
         Information); 
@@ -708,7 +708,7 @@ ProcessUsbControllerInfo0(
         Information = usbController->Header.ActualBufferLength;
     }
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
         __FUNCTION__": request completed with status %x size %d\n",
         Status,
         Information); 
@@ -835,7 +835,7 @@ ProcessUsbUserRequest(
     
     if (Request)
     {
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_QUEUE,
             __FUNCTION__": %s request %s (%x) completed with status %x size %d \n",
             fdoContext->FrontEndPath,
             userRequestString,
@@ -1350,7 +1350,7 @@ PassiveDrain(
 {
     PUSB_FDO_WORK_ITEM_CONTEXT  context = WorkItemGetContext(WorkItem);
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__":Device %p\n",
         context->FdoContext->WdfDevice);
     //
@@ -1425,7 +1425,7 @@ DrainRequestQueue(
                     if (!FromPassiveLevel &&
                         Urb->UrbHeader.Function == URB_FUNCTION_SELECT_INTERFACE)
                     {
-                        TraceEvents(TRACE_LEVEL_WARNING, TRACE_QUEUE,
+                        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_QUEUE,
                             __FUNCTION__ ": Device %p Request %p URB_FUNCTION_SELECT_INTERFACE processing from DPC\n",
                             fdoContext->WdfDevice,
                             Request);

--- a/Drivers/xenvusb/RootHubPdo.cpp
+++ b/Drivers/xenvusb/RootHubPdo.cpp
@@ -506,7 +506,7 @@ CreateRootHubPdoWithDeviceInit(
     else
     {
         // for the log:
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
             __FUNCTION__": %s WDFDEVICE %p child PDO WDFDEVICE %p\n",
             fdoContext->FrontEndPath,
             fdoContext->WdfDevice,
@@ -528,7 +528,7 @@ RootHubPreProcessPnpIrp(
     NTSTATUS Status = Irp->IoStatus.Status;
     PIO_STACK_LOCATION IoStack = IoGetCurrentIrpStackLocation(Irp);
     PCHAR requeststring = "Unknown";
-    ULONG traceLevel = TRACE_LEVEL_INFORMATION;
+    ULONG traceLevel = TRACE_LEVEL_VERBOSE;
 
     switch (IoStack->MinorFunction)
     {
@@ -612,7 +612,7 @@ RootHubPreProcessPnpIrp(
         requeststring = "IRP_MN_DEVICE_USAGE_NOTIFICATION";
         break;
     case IRP_MN_SURPRISE_REMOVAL:
-        traceLevel = TRACE_LEVEL_WARNING;
+        traceLevel = TRACE_LEVEL_INFORMATION;
         requeststring = "IRP_MN_SURPRISE_REMOVAL";
         break;
     default:
@@ -636,7 +636,7 @@ RootHubPreProcessCreateIrp(
     IN PIRP Irp)
 {
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__"\n");    
     
     IoSkipCurrentIrpStackLocation(Irp);
@@ -657,7 +657,7 @@ HubEvtDeviceD0Entry(
 {
     PUSB_HUB_PDO_CONTEXT hubContext = DeviceGetHubPdoContext(Device);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Device %p PreviousState %s\n",
         hubContext->WdfDevice,
         DbgDevicePowerString(PreviousState));
@@ -698,7 +698,7 @@ HubEvtDeviceD0Exit(
 { 
     PUSB_HUB_PDO_CONTEXT hubContext = DeviceGetHubPdoContext(Device);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Device %p TargetState %s\n",
         hubContext->WdfDevice,
         DbgDevicePowerString(TargetState));
@@ -720,7 +720,7 @@ VOID HubEvtDeviceSurpriseRemoval(
 {
     PUSB_HUB_PDO_CONTEXT hubContext = DeviceGetHubPdoContext(Device);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Device %p unplugged\n",
         hubContext->WdfDevice);
 
@@ -735,6 +735,7 @@ HubEvtDeviceQueryRemove (
 {
     PUSB_HUB_PDO_CONTEXT hubContext = DeviceGetHubPdoContext(Device);  
 
+    // Leave as a warning, devices should be surprise removed with no queries.
     TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
         __FUNCTION__": Device %p\n",
         hubContext->WdfDevice);
@@ -913,7 +914,7 @@ ProcessHubGetNodeInformation(
         Information = sizeof(USB_NODE_INFORMATION);
     }
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s completing request with status %x\n",
         fdoContext->FrontEndPath,
         Status);
@@ -1019,7 +1020,7 @@ ProcessHubGetNodeConnectionInformation(
         }
     }
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s length %d needed %d pipes %d requested %d request status %x\n",
         fdoContext->FrontEndPath,
         OutputBufferLength,
@@ -1095,7 +1096,7 @@ ProcessHubGetCapabilities(
         }
     }
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s length %d needed %d pipes %d requested %d request status %x\n",
         fdoContext->FrontEndPath,
         OutputBufferLength,
@@ -1148,7 +1149,7 @@ ProcessHubGetDescriptorFromNodeConnection(
         }
     }
         
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s completing request with status %x\n",
         fdoContext->FrontEndPath,
         Status);
@@ -1262,7 +1263,7 @@ ProcessHubCyclePort(
         }
     }
         
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s completing request with status %x\n",
         GetFdoContextFromHubDevice(hubContext->WdfDevice)->FrontEndPath,
         Status);
@@ -1296,7 +1297,7 @@ ProcessHubCyclePort(
          Information = 20;
      }
         
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": %s completing request with status %x\n",
         GetFdoContextFromHubDevice(hubContext->WdfDevice)->FrontEndPath,
         Status);
@@ -1798,7 +1799,7 @@ HubGetStringDescriptor(
 {
     UNREFERENCED_PARAMETER(packet);    
     UNREFERENCED_PARAMETER(buffer);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
         __FUNCTION__": Device %p Request %p URB %p\n",
         hubContext->WdfDevice,
         Request,
@@ -1871,7 +1872,7 @@ HubGetStatus(
     IN PUCHAR buffer,
     IN PWDF_USB_CONTROL_SETUP_PACKET packet)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": Device %p Request %p URB %p length %d\n",
         hubContext->WdfDevice,
         Request,
@@ -1952,12 +1953,12 @@ HubGetStatus(
                 if (hubContext->PortFeatureStatus & USB_PORT_STATUS_RESET)
                 {
                     hubContext->PortFeatureStatus &= ~USB_PORT_STATUS_RESET;
-                    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+                    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                         __FUNCTION__": Device %p clearing port feature reset status\n",
                         hubContext->WdfDevice);
                 }
                 ULONG level = hubContext->PortFeatureChange ? TRACE_LEVEL_WARNING : 
-                    TRACE_LEVEL_INFORMATION;
+                    TRACE_LEVEL_VERBOSE;
 
                 TraceEvents(level, TRACE_URB,
                     __FUNCTION__": Device %p Port Status %x Change %x\n",
@@ -2158,7 +2159,7 @@ HubSetFeature(
             break;
         }   
 
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
             __FUNCTION__": Device %p Feature %s %d PortFeatureStatus %x PortFeatureChange: %x\n",
             hubContext->WdfDevice,
             feature,
@@ -2195,7 +2196,7 @@ HubClearFeature(
     PCHAR feature = DecodeFeature(packet->Packet.wValue.Value);
     BOOLEAN statusChanged = FALSE;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": Device %p Request %p URB %p Feature %s %d wIndex %x\n",
         hubContext->WdfDevice,
         Request,
@@ -2256,7 +2257,7 @@ HubClearFeature(
             break;
         }
 
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
             __FUNCTION__": Device %p Feature %s %d PortFeatureChange: %x\n",
             hubContext->WdfDevice,
             feature,
@@ -2307,7 +2308,7 @@ HubControlTransferEx(
     WDF_USB_CONTROL_SETUP_PACKET packet;
     RtlCopyMemory(packet.Generic.Bytes, Urb->UrbControlTransferEx.SetupPacket, 8);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": Device %p Request %p URB %p\n"
         " bmRequest Dir %d Type %d Recipient %d bRequest %x wValue %x wIndex %x\n",
         hubContext->WdfDevice,
@@ -2331,7 +2332,7 @@ HubControlTransferEx(
     if (buffer == NULL)
     {
         // this can be ok.
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
             __FUNCTION__": device %p buffer is NULL\n",
             hubContext->WdfDevice);
     }
@@ -2446,7 +2447,7 @@ HubControlTransferEx(
         }
     }
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": device %p bRequest %s (%x) unsupported\n",
         hubContext->WdfDevice,
         transferRequest, 
@@ -2769,7 +2770,7 @@ HubCheckStatusChange(
             hubContext->ReportedStatus = hubContext->PortFeatureChange;
             context->Buffer[0] = 0x02; // port 1.
 
-            TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
                 __FUNCTION__": Device %p Request %p PortFeatureChange %x\n",
                 hubContext->WdfDevice,
                 Request,
@@ -2864,7 +2865,7 @@ HubProcessHubInterruptRequest(
 
     RtlZeroMemory(buffer, Urb->UrbBulkOrInterruptTransfer.TransferBufferLength);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
             __FUNCTION__": Device %p Pipehandle %p Interrupt pipe %p length %d Queued\n",
             hubContext->WdfDevice,
             Urb->UrbBulkOrInterruptTransfer.PipeHandle,
@@ -2909,7 +2910,7 @@ HubProcessUrb(
 {
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": Device %p Request %p URB %p Function %x\n",
         hubContext->WdfDevice,
         Request,
@@ -3042,7 +3043,7 @@ HubEvtIoInternalDeviceControl(
                 *rootHubPdo = WdfDeviceWdmGetDeviceObject(hubContext->WdfDevice); // Root HUB PDO 
             }
 
-            TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": IOCTL_INTERNAL_USB_GET_PARENT_HUB_INFO for device %p p1 %p p2 %p p4 %p\n",
                 hubContext->WdfDevice,
                 parameters.Parameters.Others.Arg1,
@@ -3057,7 +3058,7 @@ HubEvtIoInternalDeviceControl(
             PUSB_TOPOLOGY_ADDRESS topology = 
                 (PUSB_TOPOLOGY_ADDRESS) parameters.Parameters.Others.Arg1;            
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": IOCTL_INTERNAL_USB_GET_TOPOLOGY_ADDRESS for device %p\n",
                 hubContext->WdfDevice);
 
@@ -3075,7 +3076,7 @@ HubEvtIoInternalDeviceControl(
 
     case IOCTL_INTERNAL_USB_RESET_PORT:
 
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                     __FUNCTION__": Device %p IOCTL_INTERNAL_USB_RESET_PORT\n",
                     hubContext->WdfDevice);
 
@@ -3137,7 +3138,7 @@ HubEvtIoInternalDeviceControl(
                 }
                 *portStatus = (ULONG) hubContext->PortFeatureStatus;
                 Status = STATUS_SUCCESS;
-                TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                     __FUNCTION__": device %p IOCTL_INTERNAL_USB_GET_PORT_STATUS port 1 status %x\n",
                     hubContext->WdfDevice,
                     *portStatus);
@@ -3163,7 +3164,7 @@ HubEvtIoInternalDeviceControl(
                 (PUSB_DEVICE_HANDLE *) parameters.Parameters.Others.Arg1;
             *pHandle = hubContext;
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": IOCTL_INTERNAL_USB_GET_DEVICE_HANDLE for device %p p1 %p p2 %p p4 %p\n",
                 hubContext->WdfDevice,
                 parameters.Parameters.Others.Arg1,
@@ -3189,7 +3190,7 @@ HubEvtIoInternalDeviceControl(
             PVOID * arg2 = (PVOID *) parameters.Parameters.Others.Arg2;
             *arg2 = (PVOID) hubContext->Port; // ???
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": IOCTL_INTERNAL_USB_GET_DEVICE_HANDLE_EX for device %p p1 %p p2 %p p4 %p\n",
                 hubContext->WdfDevice,
                 parameters.Parameters.Others.Arg1,
@@ -3204,7 +3205,7 @@ HubEvtIoInternalDeviceControl(
             PHUB_DEVICE_CONFIG_INFO configInfo = 
                 (PHUB_DEVICE_CONFIG_INFO) parameters.Parameters.Others.Arg1;
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": IOCTL_INTERNAL_USB_GET_DEVICE_CONFIG_INFO for device %p\n",
                 hubContext->WdfDevice);
             configInfo->Version = 1;
@@ -3295,7 +3296,7 @@ HubEvtIoStop(
     _In_ ULONG ActionFlags
 )
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, 
+    TraceEvents(TRACE_LEVEL_VERBOSE, 
                 TRACE_QUEUE, 
                 __FUNCTION__": Queue 0x%p, Request 0x%p ActionFlags %d", 
                 Queue, Request, ActionFlags);
@@ -3318,7 +3319,7 @@ HubStatusChangeEvtIoStop(
     _In_ ULONG ActionFlags
 )
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, 
+    TraceEvents(TRACE_LEVEL_VERBOSE, 
                 TRACE_QUEUE, 
                 __FUNCTION__": Queue 0x%p, Request 0x%p ActionFlags %d", 
                 Queue, Request, ActionFlags);

--- a/Drivers/xenvusb/Trace.h
+++ b/Drivers/xenvusb/Trace.h
@@ -56,12 +56,7 @@ static inline void __XenTrace(XEN_TRACE_LEVEL level, ULONG flags, PCSTR fmt, ...
 
     UNREFERENCED_PARAMETER(flags);
 
-    // --XT-- XXX TODO This is a temporary fix to deal with the really
-    // loud tracing. See the logging comment in xenif.cpp for more info.
-    if (level < XenTraceLevelWarning)
-    {
-        return;
-    }
+    // --XT-- Restored information level tracking - keep an eye on it.
 
 	va_start(args, fmt);
 	___XenTrace(level, XENTARGET,  sizeof(XENTARGET)-1, fmt, args);

--- a/Drivers/xenvusb/UsbInterface.cpp
+++ b/Drivers/xenvusb/UsbInterface.cpp
@@ -48,7 +48,7 @@ FdoInterfaceReference(
 {
   PUSB_FDO_CONTEXT fdoContext = (PUSB_FDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
   InterlockedIncrement(&fdoContext->busInterfaceReferenceCount);
@@ -60,7 +60,7 @@ FdoInterfaceDereference(
 { 
   PUSB_FDO_CONTEXT fdoContext = (PUSB_FDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
   //
@@ -177,7 +177,7 @@ FdoSubmitIsoOutUrb(
     IN PVOID Context,
     IN PURB )
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Context %p\n",
         Context);
 
@@ -205,7 +205,7 @@ FdoQueryBusInformation(
 {
     PUSB_FDO_CONTEXT fdoContext = (PUSB_FDO_CONTEXT) Context;
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Context %p\n",
         Context);
 
@@ -296,7 +296,7 @@ FdoQueryBusInformation(
     } while (0);
 
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Context %p; Level %d Status %x\n",
         Context, 
         Level,
@@ -313,7 +313,7 @@ FdoEnumLogEntry(
     ULONG,
     ULONG)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Context %p\n",
         Context);
 
@@ -329,7 +329,7 @@ FdoIsDeviceHighSpeed(
     //
     // XXX lie 
     //
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Context %p\n",
         Context);
 
@@ -539,7 +539,7 @@ FdoPreProcessQueryInterface(
         }
         if (provideInterface)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": %s USB_BUS_INTERFACE_USBDI version %d\n",
                 fdoContext->FrontEndPath,
                 IoStack->Parameters.QueryInterface.Version);
@@ -567,7 +567,7 @@ RootHubIfInterfaceReference(
 {
   PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
   InterlockedIncrement(&hubContext->BusInterfaceReferenceCount);
@@ -579,7 +579,7 @@ RootHubIfInterfaceDereference(
 { 
   PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
   //
@@ -675,7 +675,7 @@ RootHubIfInitializeUsbDevice(
     _In_ PVOID BusContext,
     _Inout_ PUSB_DEVICE_HANDLE DeviceHandle)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__"\n");
     UNREFERENCED_PARAMETER(BusContext);
     UNREFERENCED_PARAMETER(DeviceHandle);
@@ -861,7 +861,7 @@ RootHubIfRemoveUsbDevice (
 {
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__" %s Device %p Flags %x DeviceHandleRefCount %d\n",
         GetFdoContextFromHubDevice(hubContext->WdfDevice)->FrontEndPath,
         hubContext->WdfDevice,
@@ -983,7 +983,7 @@ RootHubIfRestoreUsbDevice (
     UNREFERENCED_PARAMETER(NewDeviceHandle);
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         GetFdoContextFromHubDevice(hubContext->WdfDevice)->FrontEndPath);
     return STATUS_SUCCESS;
@@ -1141,7 +1141,7 @@ RootHubIfInitialize20Hub (
     _In_ PUSB_DEVICE_HANDLE HubDeviceHandle,
     _In_ ULONG TtCount)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__"\n");
 
     UNREFERENCED_PARAMETER(HubDeviceHandle);
@@ -1161,7 +1161,7 @@ RootHubIfGetDeviceBusContext (
     _In_ PVOID DeviceHandle)
 {
     UNREFERENCED_PARAMETER(DeviceHandle);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__"\n");
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
@@ -1184,7 +1184,7 @@ RoottHubIfGetRootHubSymbolicName (
     _In_ ULONG HubSymNameBufferLength,
     _Out_ PULONG HubSymNameActualLength)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__"\n");
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
@@ -1263,7 +1263,7 @@ RootHubIfGetExtendedHubInformation (
     _In_ ULONG HubInformationBufferLength,
     _Out_ PULONG LengthOfDataCopied)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__":\n");
 
     UNREFERENCED_PARAMETER(HubPhysicalDeviceObject);
@@ -1319,7 +1319,7 @@ RootHubIfControllerSelectiveSuspend (
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s %s\n",
         fdoContext->FrontEndPath,
         Enable ? "Enable" : "Disable"); // @todo too high.
@@ -1460,7 +1460,7 @@ RootHubIfFlushTransfers (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 }
@@ -1481,7 +1481,7 @@ RootHubIfSetDeviceHandleData (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 }
@@ -1501,7 +1501,7 @@ RootHubIfSetDeviceHandleIdleReadyState (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 
@@ -1573,7 +1573,7 @@ RootHubIfGetDeviceAddress (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
     *DeviceAddress = 1;
@@ -1589,7 +1589,7 @@ RootHubIfWaitAsyncPowerUp (
 {
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
     return STATUS_SUCCESS;
@@ -1641,15 +1641,13 @@ RootHubIfHubTestPoint (
     _In_ ULONG Opcode,
     _In_ PVOID TestData)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__"\n");
 
     UNREFERENCED_PARAMETER(DeviceHandle);
     UNREFERENCED_PARAMETER(Opcode);
     UNREFERENCED_PARAMETER(TestData);
-
-    PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
-    UNREFERENCED_PARAMETER(hubContext);
+    UNREFERENCED_PARAMETER(BusContext);
     return STATUS_SUCCESS;
 }
 
@@ -1668,7 +1666,7 @@ RootHubIfSetDeviceFlag (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 }
@@ -1684,7 +1682,7 @@ RootHubIfSetBusSystemWakeMode (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 }
@@ -1702,7 +1700,7 @@ RootHubIfCaculatePipeBandwidth (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
     return 0;
@@ -1714,11 +1712,10 @@ USB_BUSIFFN
 RootHubIfReleaseBusSemaphore (
     _In_ PVOID BusContext)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__"\n");
 
-    PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
-    UNREFERENCED_PARAMETER(hubContext);
+    UNREFERENCED_PARAMETER(BusContext);
 }
 
 _Function_class_(USB_BUSIFFN_ACQUIRE_SEMAPHORE)
@@ -1727,11 +1724,10 @@ USB_BUSIFFN
 RootHubIfAcquireBusSemaphore (
     _In_ PVOID BusContext)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__"\n");
 
-    PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
-    UNREFERENCED_PARAMETER(hubContext);
+    UNREFERENCED_PARAMETER(BusContext);
 }
 
 _Function_class_(USB_BUSIFFN_IS_ROOT)
@@ -1806,7 +1802,7 @@ RootHubIfAbortAllDevicePipes (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
     return STATUS_SUCCESS;
@@ -1825,7 +1821,7 @@ RootHubIfSetDeviceErrataFlag (
 
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 }
@@ -1841,7 +1837,7 @@ RootHubIfGetDebugPortNumber (
 {
     PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) BusContext;
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(hubContext->Parent);
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s\n",
         fdoContext->FrontEndPath);
 
@@ -1858,7 +1854,7 @@ RootHubIfMinidumpReference(
 {
   PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
   InterlockedIncrement(&hubContext->MinidumpInterfaceReferenceCount);
@@ -1870,7 +1866,7 @@ RootHubIfMinidumpDereference(
 { 
   PUSB_HUB_PDO_CONTEXT hubContext =(PUSB_HUB_PDO_CONTEXT) Context;
 
-  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Context %p\n",
       Context);
 
@@ -1885,7 +1881,7 @@ USB_BUSIFFN
 RootHubIfSetUsbPortMiniDumpFlags(
     IN PVOID flags)
 {
-  TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
       __FUNCTION__": Flags %p\n",
       flags);
 }
@@ -1927,7 +1923,7 @@ USB_BUSIFFN
 RootHubIfSSResumeHub(
     IN PDEVICE_OBJECT PDO)
 {
-  TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
       __FUNCTION__": PDO %p\n",
       PDO);
     return STATUS_SUCCESS;
@@ -1938,7 +1934,7 @@ USB_BUSIFFN
 RootHubIfSSSuspendHub(
     IN PDEVICE_OBJECT PDO)
 {
-  TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+  TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
       __FUNCTION__": PDO %p\n",
       PDO);
     return STATUS_UNSUCCESSFUL;
@@ -1981,7 +1977,7 @@ RootHubIfFpAllocateWorkItem(
         workItemSize,
         XVUG);
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Pdo %p\n",
         Pdo);
 
@@ -2006,7 +2002,7 @@ RootHubIfFpQueueWorkItem(
     IN PVOID  Context,
     IN BOOLEAN flag)
 {
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Device %p IoWorkItem %p WorkerRoutine %p QueueType %d Context %p flag %d\n",
         Device,
         IoWorkItem,
@@ -2035,7 +2031,7 @@ USB_BUSIFFN
 RootHubIfFpFreeWorkItem(
     IN PIO_WORKITEM IoWorkItem)
 {	
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": IoWorkItem %p\n",
         IoWorkItem);
 
@@ -2063,7 +2059,7 @@ ProcessIrpWorkItem(
 {
     PIRP_WORK_ITEM item = (PIRP_WORK_ITEM) context;
     
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": device %p context %p\n",
         device,
         context);
@@ -2107,7 +2103,7 @@ RootHubIfFpDeferIrpProcessing(
     DIRP_CALLBACK_FUNC Func,
     PIRP Irp)
 {
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Device %p Func %p Irp %p\n",
         Device,
         Func,
@@ -2289,7 +2285,7 @@ RootHubPreProcessQueryInterface(
         //
         // log all hub interfaces for now.
         //
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__": %s USB_BUS_INTERFACE_HUB version %d %s\n",
             fdoContext->FrontEndPath,
             IoStack->Parameters.QueryInterface.Version,
@@ -2314,7 +2310,7 @@ RootHubPreProcessQueryInterface(
             minidump->InterfaceDereference = RootHubIfMinidumpDereference;
             minidump->SetUsbPortMiniDumpFlags = RootHubIfSetUsbPortMiniDumpFlags;
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": USB_BUS_INTERFACE_HUB_MINIDUMP_GUID supported size %d functions %d\n",
                 minidump->Size, 3);
             
@@ -2323,7 +2319,7 @@ RootHubPreProcessQueryInterface(
         }
         else
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": %s USB_BUS_INTERFACE_HUB_MINIDUMP_GUID unsupported\n",
                 fdoContext->FrontEndPath);
         }
@@ -2349,7 +2345,7 @@ RootHubPreProcessQueryInterface(
             hubSuspend->ResumeHub = RootHubIfSSResumeHub;
             hubSuspend->SuspendHub = RootHubIfSSSuspendHub;
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": USB_BUS_INTERFACE_HUB_SS_GUID supported size %d functions %d\n",
                 hubSuspend->Size, 4);
             
@@ -2358,7 +2354,7 @@ RootHubPreProcessQueryInterface(
         }
         else
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": %s USB_BUS_INTERFACE_HUB_SS_GUID unsupported\n",
                 fdoContext->FrontEndPath);
         }
@@ -2367,13 +2363,13 @@ RootHubPreProcessQueryInterface(
         *IoStack->Parameters.QueryInterface.InterfaceType))
     {
         // this is the controller interface, ignored here, processed by the controller device.
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": USB_BUS_INTERFACE_USBDI_GUID passed down to controller\n");
     }
     else if ( InlineIsEqualGUID( GUID_PNP_LOCATION_INTERFACE,
         *IoStack->Parameters.QueryInterface.InterfaceType))
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__": GUID_PNP_LOCATION_INTERFACE unsupported\n");
     }
     else if ( InlineIsEqualGUID( USB_BUS_INTERFACE_HUB_FORWARD_PROGRESS_GUID,
@@ -2399,7 +2395,7 @@ RootHubPreProcessQueryInterface(
             fp->FreeWorkItem = RootHubIfFpFreeWorkItem;
             fp->DeferIrpProcessing = RootHubIfFpDeferIrpProcessing;
 
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": %s USB_BUS_INTERFACE_HUB_FORWARD_PROGRESS_GUID supported size %d functions %d\n",
                 fdoContext->FrontEndPath,
                 fp->Size, 6);

--- a/Drivers/xenvusb/UsbRequest.cpp
+++ b/Drivers/xenvusb/UsbRequest.cpp
@@ -179,7 +179,7 @@ SubmitUrb(
         WdfRequestComplete(Request, STATUS_UNSUCCESSFUL);
         AcquireFdoLock(fdoContext);
 
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
             __FUNCTION__": Bad URB header\n");
 
         return;
@@ -191,14 +191,16 @@ SubmitUrb(
     Urb->UrbHeader.Status = USBD_STATUS_SUCCESS;
 
     PCHAR UrbFuncString = UrbFunctionToString(Urb->UrbHeader.Function);
+
+    /* --XT-- This might be the source of so much of the info tracing, taking it out...
     ULONG traceLevel = TRACE_LEVEL_VERBOSE;
     if ((Urb->UrbHeader.Function != URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER) &&
         (Urb->UrbHeader.Function != URB_FUNCTION_ISOCH_TRANSFER) &&
         (Urb->UrbHeader.Function != URB_FUNCTION_CLASS_INTERFACE))
     {
         traceLevel = TRACE_LEVEL_INFORMATION;
-    }
-    TraceEvents(traceLevel, TRACE_URB,
+    }*/
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": Start processing Request %p URB Function %s requests on ringbuffer: %d\n",
         Request,
         UrbFuncString,
@@ -254,7 +256,7 @@ SubmitUrb(
 
                 Urb->UrbControlDescriptorRequest.TransferBufferLength = bytesToCopy;
 
-                TraceEvents(traceLevel, TRACE_URB,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                     __FUNCTION__": Device config descriptor %d processed locally %d bytes returned\n",
                     Urb->UrbControlDescriptorRequest.Index,
                     bytesToCopy);
@@ -284,7 +286,7 @@ SubmitUrb(
                 bytesToCopy);
 
             Urb->UrbControlDescriptorRequest.TransferBufferLength = bytesToCopy;
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": device descriptor processed locally %d bytes returned\n",
                 bytesToCopy);
 
@@ -342,7 +344,7 @@ SubmitUrb(
     case URB_FUNCTION_SELECT_CONFIGURATION:
         if (fdoContext->ConfigBusy)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": URB_FUNCTION_SELECT_CONFIGURATION busy\n");
 
             RequeueRequest(fdoContext, Request);
@@ -970,7 +972,7 @@ ProcessControlTransfer(
             Urb->UrbControlTransfer.PipeHandle);
         if (endpoint)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": found ea %x direction %s\n",
                 (endpoint->bEndpointAddress & ~USB_ENDPOINT_DIRECTION_MASK),
                 USB_ENDPOINT_DIRECTION_IN(endpoint->bEndpointAddress) ? "In" : "Out");
@@ -1000,7 +1002,7 @@ ProcessControlTransfer(
         EndpointAddress &= (~USB_ENDPOINT_DIRECTION_MASK);
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": ea %x length %d\n",
         EndpointAddress,
         Urb->UrbControlTransfer.TransferBufferLength);
@@ -1089,7 +1091,7 @@ ProcessControlTransferEx(
             Urb->UrbControlTransferEx.PipeHandle);
         if (endpoint)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+            TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
                 __FUNCTION__": found ea %x direction %s\n",
                 (endpoint->bEndpointAddress & ~USB_ENDPOINT_DIRECTION_MASK),
                 USB_ENDPOINT_DIRECTION_IN(endpoint->bEndpointAddress) ? "In" : "Out");
@@ -1119,7 +1121,7 @@ ProcessControlTransferEx(
         EndpointAddress &= (~USB_ENDPOINT_DIRECTION_MASK);
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": ea %x length %d\n",
         EndpointAddress,
         Urb->UrbControlTransferEx.TransferBufferLength);
@@ -1237,7 +1239,7 @@ ProcessIdleNotificationRequest(
     }
     fdoContext->IdleRequest = Request;
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": %s IDLE Request %p IdleCallback = %p; IdleContext = %p Device %p accepted and deferred\n",
         fdoContext->FrontEndPath,
         Request,
@@ -1634,7 +1636,7 @@ SetConfiguration(
     packet.Packet.wIndex.Value = 0;
     packet.Packet.wLength = 0;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": USB Request header RequestType %x Request %x Value %x Index %x Length %x Irp %p\n",
         packet.Packet.bm.Byte,
         packet.Packet.bRequest,
@@ -1809,7 +1811,7 @@ ProcessSelectInterface(
     packet.Packet.wIndex.Value = Interface;
     packet.Packet.wLength = 0;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": %s Interface %x Alternate %x\n",
         fdoContext->FrontEndPath,
         packet.Packet.wIndex.Value,
@@ -1888,7 +1890,7 @@ PostProcessSelectInterface(
     ASSERT(fdoContext->ConfigBusy);
     fdoContext->ConfigBusy = FALSE;
 
-    TraceEvents(TRACE_LEVEL_ERROR, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": %s interface %d %d complete\n",
         fdoContext->FrontEndPath,
         Urb->UrbSelectInterface.Interface.InterfaceNumber,
@@ -1906,7 +1908,7 @@ ProcessAbortPipe(
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
     WDF_USB_CONTROL_SETUP_PACKET packet;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ":  Urb %p Request %p\n",
         Urb,
         Request);
@@ -1917,7 +1919,7 @@ ProcessAbortPipe(
         Urb->UrbPipeRequest.PipeHandle);
     if (endpoint)
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
             __FUNCTION__ ": found ea %x direction %s\n",
             (endpoint->bEndpointAddress & ~USB_ENDPOINT_DIRECTION_MASK),
             USB_ENDPOINT_DIRECTION_IN(endpoint->bEndpointAddress) ? "In" : "Out");
@@ -1972,7 +1974,7 @@ ProcessClearOrSetFeature(
         return;
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": target:%x %s %s index:%x\n",
         requestType,
         request == USB_REQUEST_CLEAR_FEATURE ? "CLEAR_FEATURE" : "SET_FEATURE",
@@ -2131,7 +2133,7 @@ ProcessClassOrVendorCommand(
     packet.Packet.wIndex.Value = Urb->UrbControlVendorClassRequest.Index;
     packet.Packet.wLength = (USHORT) Urb->UrbControlVendorClassRequest.TransferBufferLength;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__ ": bm:%x Req:%x Val:%x Ind:%x Len:%x\n",
         packet.Packet.bm.Byte,
         packet.Packet.bRequest,
@@ -2232,7 +2234,7 @@ ProcessGetDescriptor(
     packet.Packet.wLength = (USHORT) Urb->UrbControlDescriptorRequest.TransferBufferLength;
 
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": %s (%x) Recipient %x Value %x Index %x Length %x Request %p\n",
         DescriptorTypeToString(packet.Packet.wValue.Bytes.HiByte),
         packet.Packet.wValue.Bytes.HiByte,
@@ -2262,7 +2264,7 @@ ProcessGetStatus(
 {
     WDF_USB_CONTROL_SETUP_PACKET packet;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": recipient %x Urb %p Request %p length %x\n",
         Recipient,
         Urb,
@@ -2309,7 +2311,7 @@ ProcessGetStatus(
     packet.Packet.wIndex.Value = Urb->UrbControlGetStatusRequest.Index;
     packet.Packet.wLength = 2;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         __FUNCTION__": bm:%x Req:%x Val:%x Ind:%x Len:%x\n",
         packet.Packet.bm.Byte,
         packet.Packet.bRequest,
@@ -2366,7 +2368,7 @@ EvtFdoOnHardwareRequestCancelled(
     PUSB_FDO_CONTEXT fdoContext = DeviceGetFdoContext(
         WdfIoQueueGetDevice( WdfRequestGetIoQueue(Request)));
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": %s Device %p Request %p OnRingbuffer %d\n",
         fdoContext->FrontEndPath,
         fdoContext->WdfDevice,
@@ -2585,7 +2587,7 @@ ResetDeviceWorker(
     AcquireFdoLock(context->FdoContext);    
     WDFREQUEST Request = (WDFREQUEST) context->Params[0];
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__ ": %s Device %p requests on ringbuffer %d\n",
         context->FdoContext->FrontEndPath,
         context->FdoContext->WdfDevice,
@@ -2675,7 +2677,7 @@ AbortEndpointWaitWorker(
     WDFREQUEST Request = (WDFREQUEST) context->Params[1];
     PIPE_DESCRIPTOR * pipe = (PIPE_DESCRIPTOR *) context->Params[2];
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__ ": %s Device %p ea %x request %p pipe %p\n",
         context->FdoContext->FrontEndPath,
         context->FdoContext->WdfDevice,
@@ -2771,7 +2773,7 @@ AbortEndpointWorker(
     UCHAR endpointAddress = (UCHAR) context->Params[0];
     WDFREQUEST Request = (WDFREQUEST) context->Params[1];
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__ ": %s Device %p ea %x request %p pipe %p\n",
         context->FdoContext->FrontEndPath,
         context->FdoContext->WdfDevice,
@@ -2834,7 +2836,7 @@ AbortEndpointWorker(
         WDF_USB_CONTROL_SETUP_PACKET packet;
         RtlZeroMemory(&packet, sizeof(WDF_USB_CONTROL_SETUP_PACKET));
 
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
             __FUNCTION__ ": %s Device %p endpoint %x\n",
             context->FdoContext->FrontEndPath,
             context->FdoContext->WdfDevice,
@@ -2894,7 +2896,7 @@ AbortEndpointWorker(
             Status = STATUS_UNSUCCESSFUL;
         }
 
-        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
             __FUNCTION__ ": %s Device %p abort pipe %p request for %x succeeded abortWaiters %d\n",
             context->FdoContext->FrontEndPath,
             context->FdoContext,

--- a/Drivers/xenvusb/xenif.cpp
+++ b/Drivers/xenvusb/xenif.cpp
@@ -646,7 +646,7 @@ PutShadowOnFreelist(
     ASSERT(shadow->InUse == TRUE);
     if (!shadow->InUse)
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
             __FUNCTION__ ": shadow %d not in use!\n",
             shadow->req.id);
         return;
@@ -683,7 +683,7 @@ PutShadowOnFreelist(
             {
                 if (!PutGrantOnFreelist(Xen, indirectPage[index].gref[index2]))
                 {
-                    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+                    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
                         __FUNCTION__": leaked grant ref %p for indirect data segment\n",
                         indirectPage[index].gref[index2]);
                 }
@@ -696,7 +696,7 @@ PutShadowOnFreelist(
     {
         if (!PutGrantOnFreelist(Xen, shadow->req.gref[index]))
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
                 __FUNCTION__": leaked grant ref %p for data segment\n",
                 shadow->req.gref[index]);
         }
@@ -708,8 +708,8 @@ PutShadowOnFreelist(
     ASSERT(Xen->ShadowFree < Xen->ShadowArrayEntries);
     if (Xen->ShadowFree >= Xen->ShadowArrayEntries)
     {
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
-            __FUNCTION__": ShadowFree %d ShadowArrayEntries %d!\n",
+        TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
+            __FUNCTION__": ShadowFree %d >= ShadowArrayEntries %d!\n",
             Xen->ShadowFree,
             Xen->ShadowArrayEntries);
         return;
@@ -726,7 +726,7 @@ CompleteRequestsFromShadow(
 
     AcquireFdoLock(fdoContext);;
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
         __FUNCTION__": Device %p %d requests on ringbuffer\n",
         fdoContext->WdfDevice,
         OnRingBuffer(fdoContext->Xen));
@@ -796,7 +796,7 @@ CompleteRequestsFromShadow(
             WdfRequestComplete(Request, STATUS_DEVICE_DOES_NOT_EXIST);
             AcquireFdoLock(fdoContext);;
 
-            TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
                 __FUNCTION__": Device %p completing on hardware Request %p\n",
                 fdoContext->WdfDevice,
                 Request);
@@ -805,7 +805,7 @@ CompleteRequestsFromShadow(
     
     ReleaseFdoLock(fdoContext);
 
-    TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
         __FUNCTION__": Device %p removed %d requests from ringbuffer\n",
         fdoContext->WdfDevice,
         RequestsProcessed);
@@ -881,7 +881,7 @@ AllocateGrefs(
 {
     ULONG index;
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__ "==> PagesUsed: %d (0x%x)\n", PagesUsed, PagesUsed);
 
     for (index = 0;
@@ -892,7 +892,7 @@ AllocateGrefs(
         grant_ref_t gref = GetGrantFromFreelist(Xen);
         if (gref == INVALID_GRANT_REF)
         {
-            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+            TraceEvents(TRACE_LEVEL_WARNING, TRACE_DEVICE,
                 __FUNCTION__ "GetGrantFromFreelist failed\n");
             return FALSE;
         }     
@@ -905,11 +905,11 @@ AllocateGrefs(
             shadow->req.gref[shadow->req.nr_segments]);
 
         shadow->req.nr_segments++;
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__ "Mapped PFN(%d): %d (0x%x)\n", index, pfn, pfn);
     }
 
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
             __FUNCTION__ "<==\n");
     return TRUE;
 }
@@ -1362,7 +1362,7 @@ PutResetOrCycleUrbOnRing(
                 //
                 // Complete the request.
                 //
-                TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                     __FUNCTION__": Device %p Request %p shadow %p Cleanup request status %x\n",
                     fdoContext->WdfDevice,
                     Request,
@@ -1708,7 +1708,7 @@ PutUrbOnRing(
                 //
                 // Complete the request.
                 //
-                TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                     __FUNCTION__": Device %p Request %p shadow %p Mdl %p mdlAllocated %d Cleanup request status %x\n",
                     fdoContext->WdfDevice,
                     Request,
@@ -2112,7 +2112,7 @@ PutIsoUrbOnRing(
         shadow->allocatedMdl = mdlAllocated ? Mdl : NULL;
 
         RtlCopyMemory(&shadow->req.setup, packet, sizeof(shadow->req.setup));
-        TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+        TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": request: id %I64d type %d endpoint %x length %x offset %x nr_segs %d\n",
             shadow->req.id,
             shadow->req.type,
@@ -2164,7 +2164,7 @@ PutIsoUrbOnRing(
                 //
                 // Complete the request.
                 //
-                TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DEVICE,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                     __FUNCTION__": Device %p Request %p shadow %p Mdl %p mdlAllocated %d Cleanup request status %x\n",
                     fdoContext->WdfDevice,
                     Request,
@@ -2215,7 +2215,7 @@ TraceUsbIfRequest(
 {
     WDF_USB_CONTROL_SETUP_PACKET packet;
     RtlCopyMemory(&packet, &request->setup, sizeof(packet));
-    TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_URB,
+    TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_URB,
         "%s Device %p usbif_request %p\n"
         "  id %x type %x endpoint %x\n"
         "  offset %x length %x nr_segments %x\n"
@@ -2381,7 +2381,7 @@ XenDpc(
                 //
                 // resets always work.
                 //
-                TraceEvents(TRACE_LEVEL_WARNING, TRACE_DPC,
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DPC,
                     __FUNCTION__": %s reset completion\n",
                     fdoContext->FrontEndPath);
                 NtStatus = STATUS_SUCCESS;
@@ -2413,8 +2413,6 @@ XenDpc(
                     response->data,
                     shadow->isoPacketDescriptor);
 
-                ULONG traceLevel = TRACE_LEVEL_INFORMATION;
-
                 if (!NT_SUCCESS(NtStatus))
                 {
                     if (shadow->indirectPageMemory)
@@ -2433,42 +2431,42 @@ XenDpc(
                         if (shadow->req.length > fdoContext->largestIndirectTransfer)
                         {
                             fdoContext->largestIndirectTransfer = shadow->req.length;
-                            traceLevel = TRACE_LEVEL_ERROR;
+                            TraceEvents(TRACE_LEVEL_WARNING, TRACE_DPC,
+                                        __FUNCTION__": %s request length %d > largest ind xfer\n",
+                                        fdoContext->FrontEndPath, shadow->req.length);
                         }
                     }
                     else if (shadow->req.length > fdoContext->largestDirectTransfer)
                     {
                         fdoContext->largestDirectTransfer = shadow->req.length;
-                        traceLevel = TRACE_LEVEL_ERROR;
+                        TraceEvents(TRACE_LEVEL_WARNING, TRACE_DPC,
+                                    __FUNCTION__": %s request length %d > largest dir xfer\n",
+                                    fdoContext->FrontEndPath, shadow->req.length);
                     }
                 }
 
-                // --XT-- XXX TODO shorting this logging out if it is not errors or
-                // warnings. As noted, the logging needs work. Maybe at some point
-                // this can be restored for debugging though is is quite noisy.
-                if ((traceLevel == TRACE_LEVEL_ERROR)||(traceLevel == TRACE_LEVEL_WARNING))
-                {
-                    TraceEvents(traceLevel, TRACE_DPC,
-                        __FUNCTION__": %s %s usbif status %x (%s) usbd status %x (%s) ntstatus %x\n"
-                        "request type %x endpoint %x offset %d length %d nr_segments %d flags %x\n"
-                        "nr_packets %d startframe %d indirectPageMemory %p\n",
-                        fdoContext->FrontEndPath,
-                        response->status ? "response error" : "response",
-                        response->status,
-                        usbifStatusString,
-                        usbdStatus,
-                        usbdStatusString,
-                        NtStatus,
-                        shadow->req.type,
-                        shadow->req.endpoint,
-                        shadow->req.offset,
-                        shadow->req.length,
-                        shadow->req.nr_segments,
-                        shadow->req.flags,
-                        shadow->req.nr_packets,
-                        shadow->req.startframe,
-                        shadow->indirectPageMemory);
-                }
+                // --XT-- Originally shorting this logging out but that was a mess. Logged
+                // warnings abovel and make this verbose.
+                TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DPC,
+                    __FUNCTION__": %s %s usbif status %x (%s) usbd status %x (%s) ntstatus %x\n"
+                    "request type %x endpoint %x offset %d length %d nr_segments %d flags %x\n"
+                    "nr_packets %d startframe %d indirectPageMemory %p\n",
+                    fdoContext->FrontEndPath,
+                    response->status ? "response error" : "response",
+                    response->status,
+                    usbifStatusString,
+                    usbdStatus,
+                    usbdStatusString,
+                    NtStatus,
+                    shadow->req.type,
+                    shadow->req.endpoint,
+                    shadow->req.offset,
+                    shadow->req.length,
+                    shadow->req.nr_segments,
+                    shadow->req.flags,
+                    shadow->req.nr_packets,
+                    shadow->req.startframe,
+                    shadow->indirectPageMemory);
             }
         }
         else
@@ -2637,7 +2635,7 @@ XenPostProcessIsoResponse(
 
         // transfer the packet descriptors back?
         TraceEvents(
-            Urb->UrbIsochronousTransfer.ErrorCount ? TRACE_LEVEL_INFORMATION : TRACE_LEVEL_VERBOSE, 
+            TRACE_LEVEL_VERBOSE, 
             TRACE_DPC,
             __FUNCTION__": packet completion: StartFrame %d  errorCount %d numberOfPackets %d totalBytes %d\n",
             startFrame,


### PR DESCRIPTION
The logging levels were a mess in the front end. Lots of normal
activity was being logged as errors and warnings. Also the info
level was previously unusable it was so verbose. Fixed that to
be more usable too.

OXT-50

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>