### PR TITLE
add support for a second backend, to be used for virtual HID devices

### DIFF
--- a/Drivers/xenvusb/xenvusb.inf
+++ b/Drivers/xenvusb/xenvusb.inf
@@ -45,6 +45,7 @@ xenvusb.sys  = 1,,
 
 [Standard.NTx86]
 %xenvusb.DeviceDesc%=xenvusb_Device,  XEN\VUSB
+%xenvusb.DeviceDesc%=xenvusb_Device,  XEN\VHID
 %xenvusb.HubDesc%=xenvusb_NullDevice,  XEN\ROOT_HUB
 
 [xenvusb_Device.NT]

--- a/Drivers/xenvusb/xenvusb64.inf
+++ b/Drivers/xenvusb/xenvusb64.inf
@@ -45,6 +45,7 @@ xenvusb.sys  = 1,,
 
 [Standard.NTamd64]
 %xenvusb.DeviceDesc%=xenvusb_Device,  XEN\VUSB
+%xenvusb.DeviceDesc%=xenvusb_Device,  XEN\VHID
 %xenvusb.HubDesc%=xenvusb_NullDevice,  XEN\ROOT_HUB
 
 [xenvusb_Device.NT]


### PR DESCRIPTION
This is the WIndows equivalent of https://github.com/OpenXT/pv-linux-drivers/pull/24

Signed-off-by: Jed <lejosnej@ainfosec.com>