### PR TITLE
[vusb] Return actual ISOCH error count from the back end

### DIFF
--- a/Drivers/inc/usbxenif.h
+++ b/Drivers/inc/usbxenif.h
@@ -168,7 +168,7 @@ struct usbif_response {
                                    /* for get speed request - the speed. rename? */
 #endif
     int16_t             status;          /* USBIF_RSP_???       */  
-    uint32_t            pad;
+    uint32_t            error_count;     /* total ISOCH error count */
 };
 typedef struct usbif_response usbif_response_t;
 


### PR DESCRIPTION
This field is not used by Windows but the headers need to be
kept in sync.

OXT-425

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>