### PR TITLE
OXT-780: Generate a container id for each port device.

### DIFF
--- a/Drivers/xenvusb/UsbInterface.cpp
+++ b/Drivers/xenvusb/UsbInterface.cpp
@@ -639,6 +639,20 @@ RootHubIfCreateUsbDevice(
         PortStatus,
         hubContext->PortDevice.DeviceHandleRefCount);
 
+    // Give the port device a container Id.
+    UUID randomUUID;
+    NTSTATUS stat = ExUuidCreate(&randomUUID);
+
+    if (NT_SUCCESS(stat))
+    {
+        hubContext->PortDevice.ContainerId = randomUUID;
+    }
+    else
+    {
+        TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
+            __FUNCTION__": Could not create container Id for device.\n");
+    }
+
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
All USB devices were being given the null GUID as their container ID. The null GUID is a reserved GUID with a special meaning, and Microsoft specifically warns against assigning the null GUID as the container ID in the default case. It seems this didn't cause any issue in Windows 7, but it caused audio endpoint enumeration to fail silently in Windows 10. This PR causes xenvusb to generate an actual GUID as the container ID for each USB device.